### PR TITLE
fix: show popup window with border in x11 enviroment, first show then…

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2233,6 +2233,7 @@ void DisplayServerX11::window_set_position(const Point2i &p_position, WindowID p
 				XFree(data);
 			}
 		}
+		XMoveWindow(x11_display, wd.x11_window, p_position.x, p_position.y);
 	}
 	XMoveWindow(x11_display, wd.x11_window, p_position.x - x, p_position.y - y);
 	_update_real_mouse_position(wd);


### PR DESCRIPTION
… move up and left appearance

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
